### PR TITLE
Checkout latest compatible branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Here are the features currently supported by the Ethereum Discovery dissector (w
 
 ```
 $ cd ${WIRESHARK_SRC}
+$ git checkout wireshark-2.6.2
 $ mkdir ../wireshark-ninja
 $ cd ../wireshark-ninja
 $ cmake -G Ninja ../wireshark


### PR DESCRIPTION
The Ethereum Dissectors plugin only builds against the version 2.6.2 of Wireshark without running into build errors. This branch should be checked out before continuing with the instructions.